### PR TITLE
test concurrent global requestInfo

### DIFF
--- a/src/app/Headers.tsx
+++ b/src/app/Headers.tsx
@@ -1,0 +1,9 @@
+import { requestInfo as r } from 'rwsdk/worker'
+
+export function Headers() {
+  return (
+    <p className="whitespace-pre-line">
+      <b>r.request.headers</b>: {JSON.stringify(Object.fromEntries(r.request.headers), null, 2)}
+    </p>
+  )
+}

--- a/src/app/IsDev.tsx
+++ b/src/app/IsDev.tsx
@@ -1,0 +1,9 @@
+import { IS_DEV } from 'rwsdk/constants'
+
+export function IsDev() {
+  return (
+    <p>
+      <b>IS_DEV</b>: {IS_DEV ? 'true' : 'false'}
+    </p>
+  )
+}

--- a/src/app/Page.tsx
+++ b/src/app/Page.tsx
@@ -1,7 +1,9 @@
 import { requestInfo as r } from 'rwsdk/worker'
 import { Layout } from './Layout'
-import { IS_DEV } from 'rwsdk/constants'
 import { Url } from './Url'
+import { Headers } from './Headers'
+import { Params } from './Params'
+import { IsDev } from './IsDev'
 
 async function sleep(s: number) {
   return new Promise(resolve => setTimeout(resolve, s * 1000))
@@ -30,15 +32,9 @@ export async function Page() {
         <p>This is a server component</p>
         <p>{new Date().toISOString()}</p>
         <Url />
-        <p>
-          <b>IS_DEV</b>: {IS_DEV ? 'true' : 'false'}
-        </p>
-        <p className="whitespace-pre-line">
-          <b>r.params</b>: {JSON.stringify(r.params, null, 2)}
-        </p>
-        <p className="whitespace-pre-line">
-          <b>r.request.headers</b>: {JSON.stringify(Object.fromEntries(r.request.headers), null, 2)}
-        </p>
+        <IsDev />
+        <Params />
+        <Headers />
       </div>
     </Layout>
   )

--- a/src/app/Page.tsx
+++ b/src/app/Page.tsx
@@ -1,8 +1,18 @@
-import type { RequestInfo } from 'rwsdk/worker'
+import { requestInfo as r } from 'rwsdk/worker'
 import { Layout } from './Layout'
 import { IS_DEV } from 'rwsdk/constants'
+import { Url } from './Url'
 
-export function Page(r: RequestInfo) {
+async function sleep(s: number) {
+  return new Promise(resolve => setTimeout(resolve, s * 1000))
+}
+
+export async function Page() {
+  const url = new URL(r.request.url)
+  const sleepTime = Number(url.searchParams.get('sleep'))
+  if (sleepTime > 0) {
+    await sleep(sleepTime)
+  }
   const pathname = new URL(r.request.url).pathname
   const pages: Record<string, string> = {
     '/': 'Home',
@@ -16,11 +26,10 @@ export function Page(r: RequestInfo) {
       <title>{title + ' minimal-rwsdk-rsc'}</title>
       <div className="m-3">
         <h1 className="text-center text-2xl font-bold border-b border-gray-200 mb-2">{title}</h1>
+        {sleepTime > 0 && <p>Sleeping {sleepTime} seconds</p>}
         <p>This is a server component</p>
         <p>{new Date().toISOString()}</p>
-        <p>
-          <b>r.request.url</b>: {r.request.url}
-        </p>
+        <Url />
         <p>
           <b>IS_DEV</b>: {IS_DEV ? 'true' : 'false'}
         </p>

--- a/src/app/Params.tsx
+++ b/src/app/Params.tsx
@@ -1,0 +1,9 @@
+import { requestInfo as r } from 'rwsdk/worker'
+
+export function Params() {
+  return (
+    <p className="whitespace-pre-line">
+      <b>r.params</b>: {JSON.stringify(r.params, null, 2)}
+    </p>
+  )
+}

--- a/src/app/Url.tsx
+++ b/src/app/Url.tsx
@@ -1,0 +1,9 @@
+import { requestInfo as r } from 'rwsdk/worker'
+
+export async function Url() {
+  return (
+    <p>
+      <b>r.request.url</b>: {r.request.url}
+    </p>
+  )
+}


### PR DESCRIPTION
Making sure that when concurrent requests occur, the global requestInfo context is still correct. 

This PR adds a `sleep` query parameter e.g. https://minimal-rwsdk-rsc.jldec.workers.dev/?sleep=1 will delay server side rendering by 1 second.

All server side components use a global `import { requestInfo as r } from 'rwsdk/worker'`

By reloading multiple pages from different browser tabs with sleep > 0, you can easily trigger concurrent requests.

The values in the global requestInfo should not be affected by concurrent requests. (this is confirmed)